### PR TITLE
fix 2.3 solution: replace wg.Done with wg.Wait

### DIFF
--- a/2_maps/3_once_with_map/solution/main.go
+++ b/2_maps/3_once_with_map/solution/main.go
@@ -39,7 +39,7 @@ func main() {
 		}()
 	}
 
-	wg.Done()
+	wg.Wait()
 	fmt.Printf("len of ids: %d\n", len(uniqueIDs))
 	fmt.Println(uniqueIDs)
 }


### PR DESCRIPTION
В решении задачи `2_maps/3_once_with_map` вместо `wg.Wait()` написан `wg.Done()`, поэтому выскакивает ошибка:

```
panic: sync: negative WaitGroup counter
```

Этот PR исправляет `wg.Done()` на `wg.Wait()`.