### PR TITLE
propose 3_chan/2_select 3_chan/5_batch_stream fix

### DIFF
--- a/3_chan/2_select/solution/main.go
+++ b/3_chan/2_select/solution/main.go
@@ -9,8 +9,7 @@ import (
 
 // add ctx with timeout
 func main() {
-	chanForResp := make(chan int)
-	go RPCCall(chanForResp)
+	chanForResp := RPCCall()
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 	select {
@@ -19,10 +18,24 @@ func main() {
 	case <-ctx.Done():
 		fmt.Println("timeout ctx")
 	}
+
+	go func() {
+		fmt.Println(<-chanForResp)
+	}()
+
+	time.Sleep(time.Second * 10)
 }
 
-func RPCCall(ch chan<- int) {
-	time.Sleep(time.Hour)
+func RPCCall() <-chan int {
+	chanForResp := make(chan int)
 
-	ch <- rand.Int()
+	go func() {
+		defer close(chanForResp)
+
+		time.Sleep(time.Second * 5)
+
+		chanForResp <- rand.Int()
+	}()
+
+	return chanForResp
 }


### PR DESCRIPTION
- В 3_chan/2_select если бы после вызова RPCCall программа не завершалась, то была бы утечка горутин, так как в таком случае output канал зависал на записи. Необходимо закрывать этот канал и вычитывать его после select. В решении показал, что при чтении из канала после отработки select возвращается рандомное значение из RPCCall.

- В 5_batch_stream создается иллюзия, что пайплайн выполняется значительно быстрее чем последовательное выполнение, но на самом деле это не так, просто в предложенном решении основной поток не дожидается получения результата из последнего канала. Также, если оставить каналы небуферизированными, то пайплайн выполняется неприлично долго. 